### PR TITLE
Add slash commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ typings/
 
 # compiled/transpiled code
 dist/
+.DS_Store

--- a/src/messagetype_middleware.ts
+++ b/src/messagetype_middleware.ts
@@ -38,9 +38,10 @@ export class GithubMessageTypeMiddleware extends MiddlewareSet {
             let adapter = context.adapter as GithubAdapter;
 
             const bot = await adapter.getBotUserFromAPI();
-            var mentionSyntax = '@' + bot.login;
-            var mention = new RegExp(mentionSyntax, 'i');
-            var direct_mention = new RegExp('^' + mentionSyntax, 'i');
+            const mentionSyntax = '@' + bot.login;
+            const mention = new RegExp(mentionSyntax, 'i');
+            const direct_mention = new RegExp('^' + mentionSyntax, 'i');
+            const slash_command = new RegExp('^\/\w+', 'i');
 
             if (bot.login && context.activity.text && context.activity.text.match(direct_mention)) {
                 debug('Detected as \'direct_mention\' by middleware')
@@ -53,6 +54,14 @@ export class GithubMessageTypeMiddleware extends MiddlewareSet {
             } else if (bot.login && context.activity.text && context.activity.text.match(mention)) {
                 debug('Detected as \'mention\' by middleware')
                 context.activity.channelData.botkitEventType = 'mention';
+            } else if (context.activity.text && context.activity.text.match(slash_command)) {
+                debug('Detected as \'slash_command\' by middleware')
+
+                context.activity.channelData.botkitEventType = 'slash_command';
+
+                context.activity.type = ActivityTypes.Event;
+
+                context.activity.text = context.activity.text.replace(/^\//, '');
             } else {
                 // this is an "ambient" message
             }

--- a/src/messagetype_middleware.ts
+++ b/src/messagetype_middleware.ts
@@ -41,7 +41,7 @@ export class GithubMessageTypeMiddleware extends MiddlewareSet {
             const mentionSyntax = '@' + bot.login;
             const mention = new RegExp(mentionSyntax, 'i');
             const direct_mention = new RegExp('^' + mentionSyntax, 'i');
-            const slash_command = new RegExp('^\/\w+', 'i');
+            const slash_command = new RegExp('^\/[a-z0-9]+', 'i');
 
             if (bot.login && context.activity.text && context.activity.text.match(direct_mention)) {
                 debug('Detected as \'direct_mention\' by middleware')


### PR DESCRIPTION
Add handling of slash commands in Issue/PR comments.

Slash commands are handled as events of type 'slash_command'